### PR TITLE
Fix AutoHotkey download in installer

### DIFF
--- a/start-mizukeys.ps1
+++ b/start-mizukeys.ps1
@@ -74,7 +74,7 @@ function Get-AutoHotkey {
     }
 
     # Run the request
-    Invoke-WebRequest -Uri $AHKZipUrl -Headers $headers-OutFile $AHKZipPath -ErrorAction Stop
+    Invoke-WebRequest -Uri $AHKZipUrl -Headers $headers -OutFile $AHKZipPath -ErrorAction Stop
     Expand-Archive -Path $AHKZipPath -DestinationPath $AHKBinPath -Force
     Remove-Item -Path $AHKZipPath -Force
     Write-Output "AutoHotkey downloaded and extracted to '$AHKBinPath'."


### PR DESCRIPTION
## Summary
- fix missing parameter separation when calling `Invoke-WebRequest`

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b262ece4832d9ef42eb45e4a7acb